### PR TITLE
Fixing paths and version of ios-sim

### DIFF
--- a/src/taco-remote-lib/package.json
+++ b/src/taco-remote-lib/package.json
@@ -36,7 +36,7 @@
         "should": "4.3.0"
     },
     "optionalDependencies": {
-        "ios-sim": "5.0.4"
+        "ios-sim": "^5.0.8"
     },
 
     "scripts": {


### PR DESCRIPTION
Previously the code assumed npm 2 style install paths. Now we use require.resolve to find the installed dependency, and I've updated the version to a newer one to try and address some issues I've seen.
