### PR TITLE
logFormatHelper.ts, Handle missing color style

### DIFF
--- a/src/taco-utils/logFormatHelper.ts
+++ b/src/taco-utils/logFormatHelper.ts
@@ -156,11 +156,10 @@ module TacoUtility {
         private static colorize(str: string, styles: string[]): string {
             if (styles.length > 0) {
                 styles.forEach(function (style: string): void {
-                    if (style) {
+                    if (style && colors[style]) {
                         str = colors[style](str);
-                    } else {
-                        assert(false, "unknown logger style " + style);
-                    }
+                    } 
+                    //if no style defined string will not be colorized
                 });
             }
 


### PR DESCRIPTION
The issue was that if a style is presented that does not have a matching color style then an exception will be thrown which will fail the build. The fix is to check for the presence of the color style, if it is not present then instead of failing just do not style the string.