### PR TITLE
Add support for cordova-ios 4.3.0 with XCode 8.3

### DIFF
--- a/src/taco-remote-lib/common/builder.ts
+++ b/src/taco-remote-lib/common/builder.ts
@@ -60,6 +60,7 @@ class Builder {
             .then(function (): void { self.currentBuild.updateStatus(BuildInfo.BUILDING, "UpdatingPlatform", self.currentBuild.buildPlatform); process.send(self.currentBuild); })
             .then(function (): Q.Promise<any> { return self.beforePrepare(); })
             .then(function (): Q.Promise<any> { return self.addPlatform(); })
+            .then(function (): Q.Promise<any> { return self.collectVersionInfo(); })
             .then(function (): Q.Promise<any> { return self.setSupportProperties(); })
             .then(function (): Q.Promise<any> { return self.buildPlatform(); })
             .then(function (): Q.Promise<any> { return self.afterCompile(); })
@@ -103,6 +104,10 @@ class Builder {
         }
 
         return this.ensurePlatformAdded();
+    }
+
+    protected collectVersionInfo(): Q.Promise<any> {
+        return Q({});
     }
 
     /**

--- a/src/taco-remote-lib/ios/iosBuild.ts
+++ b/src/taco-remote-lib/ios/iosBuild.ts
@@ -56,6 +56,8 @@ process.on("message", function (buildRequest: { buildInfo: BuildInfo; language: 
 class IOSBuilder extends Builder {
     public static running: boolean = false;
     private cfg: CordovaConfig;
+    private xcodeVersion: number;
+    private cordovaIosVersion: string;
 
     constructor(currentBuild: BuildInfo, cordova: Cordova.ICordova540) {
         super(currentBuild, cordova);
@@ -73,6 +75,50 @@ class IOSBuilder extends Builder {
         return Q({});
     }
 
+    protected collectVersionInfo(): Q.Promise<any> {
+        var self: IOSBuilder = this;
+
+        // Get the version of cordova-ios and XCode currently installed
+        let execDeferred: Q.Deferred<string> = Q.defer<string>();
+        child_process.exec("xcodebuild -version & cordova platforms version ios", { cwd: this.currentBuild.appDir } , function (error, stdout, stderr) {
+            if (error) {
+                execDeferred.reject(new Error(resources.getString("XCode83GetIosPlatformVersionWarning")));
+            } else {
+                execDeferred.resolve(stdout.toString());
+            }
+        });
+
+        return execDeferred.promise.then(function parseVersionsFromOutput(execOutput: string) {
+            // Parse XCode version from output
+            const xcodeVersionRegex = /^Xcode ((\d+)(?:\.)(\d+))?/;
+            const xcodeMatch = execOutput.match(xcodeVersionRegex);
+            if (xcodeMatch[1]){
+                self.xcodeVersion = parseFloat(xcodeMatch[1]);
+            }
+            else {
+                Logger.logWarning(resources.getString("XCodeVersionNumberFetchFailed"));
+            }
+
+            // Parse cordova-ios version from output
+            const iosVersionRegex = /ios ((\d+)(?:\.)(\d+)(?:\.)(\d+))?/;
+            const iosMatch = execOutput.match(iosVersionRegex);
+            if (iosMatch[0]) {
+                self.cordovaIosVersion = iosMatch[1];
+            }
+            else {
+                Logger.logWarning(resources.getString("CordovaIosVersionNumberFetchFailed"));
+            }
+
+            if (self.xcodeVersion && self.cordovaIosVersion && 
+                self.xcodeVersion >= 8.3 && 
+                semver.lt(self.cordovaIosVersion, "4.3.0")) {
+                    throw new Error(resources.getString("IncompatibleXCodeCordovaIosVersions"));
+            }
+
+            return Q({});
+        })
+    }
+
     protected afterCompile(): Q.Promise<any> {
         return this.renameApp();
     }
@@ -80,6 +126,13 @@ class IOSBuilder extends Builder {
     protected package(): Q.Promise<any> {
         var deferred: Q.Deferred<any> = Q.defer();
         var self: IOSBuilder = this;
+
+        // If we're on cordova 4.3.0, we want to bail on creating the ipa manually, but we still need the
+        // enterprise plist file.
+        if (self.cordovaIosVersion && semver.gte(self.cordovaIosVersion, "4.3.0"))
+        {
+            return self.createEnterprisePlist();
+        }
 
         // need quotes around ipa paths for xcrun exec to work if spaces in path
         var appDirName: string = this.cfg.id() + ".app";
@@ -94,14 +147,21 @@ class IOSBuilder extends Builder {
                 if (error) {
                     deferred.reject(error);
                 } else {
-                    var plistFileName: string = self.currentBuild["appName"] + ".plist";
-                    var fullPathToPlistFile: string = path.join(process.cwd(), "platforms", "ios", "build", "device", plistFileName);
-                    plist.createEnterprisePlist(self.cfg, fullPathToPlistFile);
                     deferred.resolve({});
                 }
             });
 
-        return deferred.promise;
+        return deferred.promise.then(self.createEnterprisePlist);
+    }
+
+    private createEnterprisePlist(): Q.Promise<any> {
+        var self: IOSBuilder = this;
+
+        var plistFileName: string = self.currentBuild["appName"] + ".plist";
+        var fullPathToPlistFile: string = path.join(process.cwd(), "platforms", "ios", "build", "device", plistFileName);
+        plist.createEnterprisePlist(self.cfg, fullPathToPlistFile);
+
+        return Q({});
     }
 
     private renameApp(): Q.Promise<any> {
@@ -147,34 +207,12 @@ class IOSBuilder extends Builder {
         // Sets properties necessary to support later version of XCode
         var self: any = this;
 
-        // Get the version of XCode currently installed
-        let execDeferred: Q.Deferred<string> = Q.defer<string>();
-        child_process.exec("xcodebuild -version", function (error, stdout, stderr) {
-            if (error) {
-                execDeferred.reject(new Error(resources.getString("XCode8VersionCheckWarning", error.message)));
-            } else {
-                execDeferred.resolve(stdout.toString());
-            }
-        });
-
-        // If the version of XCode isn't current enough to require DEVELOPMENT_TEAM to
-        // be set, just skip it.
-        return execDeferred.promise.then(function parseXcodeVersion(execOutput: string) {
-            const xcodeVersionRegex = /^Xcode (\d+(\.\d+)?)/;
-            const match = execOutput.match(xcodeVersionRegex);
-            if (match && match[1]) {
-                if (parseInt(match[1], 10) >= 8) {
-                    return self.ensureDevelopmentTeam();
-                } else {
-                    return;
-                }
-            } else {
-                throw(new Error(resources.getString("XCode8VersionCheckWarningCommandOutput", execOutput)));
-            }
-        }).fail(function (err) {
-            Logger.logError(err.message);
-            return;
-        });
+        if (self.xcodeVersion && self.xcodeVersion >= 8.0) {
+            return self.ensureDevelopmentTeam();
+        }
+        else {
+            return Q({});
+        }
     }
 
     private ensureDevelopmentTeam(): Q.Promise<any> {

--- a/src/taco-remote-lib/resources/en/resources.json
+++ b/src/taco-remote-lib/resources/en/resources.json
@@ -79,6 +79,12 @@
     "_XCode8VersionCheckWarning.comment": "Warning message printed when we are unable to determine the version of XCode installed and skip setting development team property. {0} is the error thrown when attempting to get the xcode version",
     "XCode8VersionCheckWarningCommandOutput": "Warning: Unable to determine the version of XCode installed. Expected a number, got: {0}\n Skipping setting development team.",
     "_XCode8VersionCheckWarningCommandOutput.comment": "Warning message printed when the command output of xcodebuild -version isn't what we expected. {0} is the command output.",
+    "XCodeVersionNumberFetchFailed": "Failed to determine the version of XCode currently installed. Your build may fail if the version installed is 8.0 or greater.",
+    "_XCodeVersionNumberFetchFailed.comment": "Warning displayed when we fail to determine the version of XCode installed.",
+    "CordovaIosVersionNumberFetchFailed": "Failed to determine the version of cordova-ios used in the project. Your build may fail if you're using XCode 8.3 with a version of cordova-ios prior to 4.3.0",
+    "_CordovaIosVersionNumberFetchFailed.comment": "Warning displayed when we fail to determine the version of cordova-ios used in the current project.",
+    "IncompatibleXCodeCordovaIosVersions": "Remotebuild requires your projects to use cordova-ios 4.3.0 or greater with XCode 8.3. Please update your cordova-ios version.",
+    "_IncompatibleXCodeCordovaIosVersions.comment": "Error thrown when the user uses an outdated version of cordova-ios with XCode 8.3",
 
     "UnsupportedPlatform": "Unable to build: requested platform not supported",
     "_UnsupportedPlatform.comment": "Message reported to the client when a request for an unsupported platform is made",


### PR DESCRIPTION
Adds support for cordova-ios 4.3.0 with Xcode 8.3. PackageApplication has been removed from xcrun in Xcode 8.3, and we were calling it directly to create the ipa for the app. However, in cordova-ios 4.3.0 and later, device builds create an ipa, so we need only detect the version of cordova-ios and skip that step.

Also added detection for if the user is using Xcode 8.3 with a version of cordova-ios less than 4.3.0, as this scenario will never work. An error message is displayed to the user instructing them to upgrade to a later version of cordova-ios.