### PR TITLE
fixes of sending telemetry

### DIFF
--- a/src/taco-utils/package.json
+++ b/src/taco-utils/package.json
@@ -20,7 +20,7 @@
         "coverage": "istanbul cover --report json node_modules/mocha/bin/_mocha -- --reporter spec"
     },
     "dependencies": {
-        "applicationinsights": "0.15.5",
+        "applicationinsights": "0.20.0",
         "colors": "^1.0.3",
         "elementtree": "0.1.6",
         "iconv-lite": "^0.4.13",

--- a/src/taco-utils/telemetry.ts
+++ b/src/taco-utils/telemetry.ts
@@ -18,8 +18,8 @@ import os = require ("os");
 import path = require ("path");
 import Q = require ("q");
 import readline = require ("readline");
-import sender = require ("applicationinsights/Library/Sender");
-import telemetryLogger = require ("applicationinsights/Library/Logging");
+import sender = require ("applicationinsights/out/Library/Sender");
+import telemetryLogger = require ("applicationinsights/out/Library/Logging");
 import winreg = require("winreg");
 
 import utilHelper = require ("./utilHelper");

--- a/src/typings/applicationinsights.d.ts
+++ b/src/typings/applicationinsights.d.ts
@@ -470,10 +470,10 @@ declare module "applicationinsights" {
     export = ApplicationInsights;
 }
 
-declare module "applicationinsights/Library/Sender" {
+declare module "applicationinsights/out/Library/Sender" {
     export = Sender;
 }
 
-declare module "applicationinsights/Library/Logging" {
+declare module "applicationinsights/out/Library/Logging" {
     export = Logging;
 }


### PR DESCRIPTION
The new version of the applicationinsights package uses the **https** protocol to send telemetry by default.